### PR TITLE
Backport patch to support a leading "-"

### DIFF
--- a/mrblib/02_slop_parser.rb
+++ b/mrblib/02_slop_parser.rb
@@ -43,7 +43,8 @@ module Slop
 
       @arguments = strings.dup
 
-      pairs.each do |flag, arg|
+      pairs.each_with_index do |pair, idx|
+        flag, arg = pair
         break if !flag
 
         # ignore everything after '--', flag or not
@@ -54,6 +55,7 @@ module Slop
 
         # support `foo=bar`
         orig_flag = flag.dup
+        orig_arg = arg
         if flag.include?("=")
           flag, arg = flag.split("=")
         end
@@ -63,6 +65,12 @@ module Slop
           # arguments (plus the arg if necessary)
           # delete argument first while we can find its index.
           if opt.expects_argument?
+
+            # if we consumed the argument, remove the next pair
+            if orig_arg == opt.value.to_s
+              pairs.delete_at(idx + 1)
+            end
+
             arguments.each_with_index do |argument, i|
               if argument == orig_flag && !orig_flag.include?("=")
                 arguments.delete_at(i + 1)

--- a/mrblib/04_slop_types.rb
+++ b/mrblib/04_slop_types.rb
@@ -44,7 +44,7 @@ module Slop
   # Cast the option argument to an Integer.
   class IntegerOption < Option
     def call(value)
-      value =~ /\A\d+\z/ && value.to_i
+      value =~ /\A-?\d+\z/ && value.to_i
     end
   end
   IntOption = IntegerOption
@@ -53,8 +53,8 @@ module Slop
   class FloatOption < Option
     def call(value)
       # TODO: scientific notation, etc.
-      value =~ /\A\d*\.*\d+\z/ && value.to_f
-    end
+      value =~ /\A-?\d*\.*\d+\z/ && value.to_f
+     end
   end
 
   # Collect multiple items into a single Array. Support

--- a/test/slop.rb
+++ b/test/slop.rb
@@ -39,6 +39,23 @@ assert("slop - parse - option - short") do
                ])
 end
 
+assert("slop - parse - option allow leading -") do
+  argv = ["-f", "-time"]
+  options = Slop.parse(argv) do |parser|
+    parser.string("-f", "Log format")
+  end
+  assert_equal([
+                 {
+                   :f => "-time",
+                 },
+                 []
+               ],
+               [
+                 options.to_hash,
+                 options.arguments,
+               ])
+end
+
 assert("slop - to_s") do
   $0 = "test/mrb.rb"
   options = Slop::Options.new


### PR DESCRIPTION
See https://github.com/leejarvis/slop/pull/192

Basically, latest slop 4.6.2 should be supported, but
it takes times to fix for mruby. so as a first step,
only leading "-" support is backported.
